### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -1,4 +1,4 @@
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from PyDictionary import PyDictionary
 from flask_restful import Resource
 from flask import g

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ Flask==1.1.1
 Flask-Prometheus==0.0.1
 Flask-RESTful==0.3.8
 futures==3.1.1
-fuzzywuzzy==0.18.0
 goslate==1.5.1
 idna==2.9
 itsdangerous==1.1.0
@@ -16,8 +15,8 @@ MarkupSafe==1.1.1
 prometheus-client==0.7.1
 prometheus-flask-exporter==0.13.0
 PyDictionary==1.5.2
-python-Levenshtein==0.12.0
 pytz==2019.3
+rapidfuzz==0.7.3
 requests==2.23.0
 six==1.14.0
 soupsieve==2.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy